### PR TITLE
Change email to emails in plugin config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ jar {
 
 assignments {
     apiUrl = "https://caddy.pal.pivotal.io"
-    email = ""
+    emails = [""]
     cohortIdentifier = ""
 }
 


### PR DESCRIPTION
We forgot to update the prerequisites codebase when we made the change from `email` to `emails` in the assignments plugin. Probably because no one does the prereqs.